### PR TITLE
Remove wagtail docs and page privacy settings

### DIFF
--- a/home/models.py
+++ b/home/models.py
@@ -4,4 +4,5 @@ from pages.models import Page
 
 
 class HomePage(Page):
+    is_creatable = False
     default_slug = 'home'

--- a/nhsuk/settings/base.py
+++ b/nhsuk/settings/base.py
@@ -41,7 +41,6 @@ INSTALLED_APPS = [
     'wagtail.wagtailsites',
     'wagtail.wagtailusers',
     'wagtail.wagtailsnippets',
-    'wagtail.wagtaildocs',
     'wagtail.wagtailimages',
     'wagtail.wagtailsearch',
     'wagtail.wagtailadmin',
@@ -151,7 +150,7 @@ OAUTH2_PROVIDER = {
 
 # Wagtail settings
 
-WAGTAIL_SITE_NAME = "nhsuk"
+WAGTAIL_SITE_NAME = "NHS.UK"
 
 # Base URL to use when referring to full URLs within the Wagtail admin backend -
 # e.g. in notification emails. Don't include '/admin' or a trailing slash

--- a/pages/models.py
+++ b/pages/models.py
@@ -16,6 +16,8 @@ from .page_elements import Components
 
 
 class Page(WagtailPage):
+    is_creatable = False
+
     def serve(self, request, *args, **kwargs):
         """
         Redirects to the live frontend version of this page.


### PR DESCRIPTION
This removes:
- the documents app as it's not needed
- the privacy switch button as it's not implemented via API