### PR TITLE
Make all live and draft links open in a new win

### DIFF
--- a/nhs_wagtailadmin/templates/wagtailadmin/home/pages_for_moderation.html
+++ b/nhs_wagtailadmin/templates/wagtailadmin/home/pages_for_moderation.html
@@ -1,0 +1,62 @@
+{% load i18n wagtailadmin_tags %}
+{% if page_revisions_for_moderation %}
+    <div class="panel nice-padding">{# TODO try moving these classes onto the section tag #}
+        <section>
+            <h2>{% trans 'Pages awaiting moderation' %}</h2>
+            <table class="listing">
+                <col />
+                <col width="30%"/>
+                <col width="15%"/>
+                <col width="15%"/>
+                <thead>
+                    <tr>
+                        <th class="title">{% trans "Title" %}</th>
+                        <th>{% trans "Parent" %}</th>
+                        <th>{% trans "Type" %}</th>
+                        <th>{% trans "Edited" %}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for revision in page_revisions_for_moderation %}
+                        <tr>
+                            <td class="title" valign="top">
+                                <h2>
+                                    <a href="{% url 'wagtailadmin_pages:edit' revision.page.id %}" title="{% trans 'Edit this page' %}">{{ revision.page.title }}</a>
+
+                                    {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=revision.page %}
+                                    {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=revision.page %}
+                                </h2>
+                                <ul class="actions">
+                                    <li>
+                                         <form action="{% url 'wagtailadmin_pages:approve_moderation' revision.id %}" method="POST">
+                                            {% csrf_token %}
+                                            <input type="submit" class="button button-small button-secondary" value="{% trans 'Approve' %}">
+                                        </form>
+                                    </li>
+                                    <li class="no-border">
+                                        <form action="{% url 'wagtailadmin_pages:reject_moderation' revision.id %}" method="POST">
+                                            {% csrf_token %}
+                                            <input type="submit" class="button button-small button-secondary no" value="{% trans 'Reject' %}">
+                                        </form>
+                                    </li>
+                                    <li><a href="{% url 'wagtailadmin_pages:edit' revision.page.id %}" class="button button-small button-secondary">{% trans 'Edit' %}</a></li>
+                                    <li><a href="{% url 'wagtailadmin_pages:preview_for_moderation' revision.id %}" class="button button-small button-secondary" target="_blank">{% trans 'Preview' %}</a></li>
+                                </ul>
+                            </td>
+                            <td valign="top">
+                                <a href="{% url 'wagtailadmin_explore' revision.page.get_parent.id %}">{{ revision.page.get_parent.title }}</a>
+                            </td>
+                            <td class="type" valign="top">
+                                {{ revision.page.content_type.model_class.get_verbose_name }}
+                            </td>
+                            <td valign="top">
+                                <div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{{ revision.created_at|timesince }} ago </div>
+                                by {{ revision.user.get_full_name|default:revision.user.get_username }}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </section>
+    </div>
+{% endif %}

--- a/nhs_wagtailadmin/templates/wagtailadmin/home/recent_edits.html
+++ b/nhs_wagtailadmin/templates/wagtailadmin/home/recent_edits.html
@@ -1,0 +1,47 @@
+{% load i18n wagtailadmin_tags %}
+{% if last_edits %}
+    <div class="panel nice-padding">{# TODO try moving these classes onto the section tag #}
+        <section>
+            <h2>{% trans "Your most recent edits" %}</h2>
+            <table class="listing listing-page">
+                <col />
+                <col width="15%"/>
+                <col width="15%"/>
+                <thead>
+                    <tr>
+                        <th class="title">{% trans "Title" %}</th>
+                        <th>{% trans "Date" %}</th>
+                        <th>{% trans "Status" %}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for revision in last_edits %}
+                        <tr>
+                            <td class="title" valign="top">
+                                <h2>
+                                    <a href="{% url 'wagtailadmin_pages:edit' revision.page.id %}" title="{% trans 'Edit this page' %}">{{ revision.page.title }}</a>
+
+                                    {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=revision.page %}
+                                    {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=revision.page %}
+                                </h2>
+                                <ul class="actions">
+                                    <li><a href="{% url 'wagtailadmin_pages:edit' revision.page.id %}" class="button button-small button-secondary">{% trans "Edit" %}</a></li>
+                                    {% if revision.page.has_unpublished_changes %}
+                                        <li><a href="{% url 'wagtailadmin_pages:view_draft' revision.page.id %}" class="button button-small button-secondary" target="_blank">{% trans 'Draft' %}</a></li>
+                                    {% endif %}
+                                    {% if revision.page.live %}
+                                        <li><a href="{{ revision.page.url }}" class="button button-small button-secondary" target="_blank">{% trans 'Live' %}</a></li>
+                                    {% endif %}
+                                </ul>
+                            </td>
+                            <td valign="top"><div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{{ revision.created_at|timesince }} ago</div></td>
+                            <td valign="top">
+                                {% include "wagtailadmin/shared/page_status_tag.html" with page=revision.page %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </section>
+    </div>
+{% endif %}

--- a/nhs_wagtailadmin/templates/wagtailadmin/pages/_preview_button_on_edit.html
+++ b/nhs_wagtailadmin/templates/wagtailadmin/pages/_preview_button_on_edit.html
@@ -4,7 +4,7 @@
     type="button"
     data-preview-disabled="{{ has_unsaved_changes|yesno:"true,false" }}"
     data-action="{% url 'wagtailadmin_pages:revisions_view' page.id current_revision.id %}"
-    data-windowname="wagtail_preview_{{ page.id }}_{{ current_revision.id }}"
+    data-windowname="wagtail_preview_{{ page.id }}"
 >
     {{ label }}
 </button>


### PR DESCRIPTION
Some live and view draft links were opening in a new window and some weren't for no apparent reason. This fixes that inconsistency.

I opened a PR to the Wagtail main repo https://github.com/torchbox/wagtail/pull/3211 as there were some other html/python files to change and it was too hacky to include it in our repo.

We should delete the `pages_for_moderation` and `recent_edits` pages if/when that PR is merged and a new version of Wagtail released.

This also changes the way edit previews work. Before each revision would open a new tab and this was confusing people as the number of tabs kept increasing.
The preview window now is unique per page, meaning that changing the page multiple time and clicking on the preview button now open the preview page in the same window.