### PR TITLE
Tweaks for Admin API

### DIFF
--- a/nhsuk/settings/base.py
+++ b/nhsuk/settings/base.py
@@ -34,6 +34,7 @@ INSTALLED_APPS = [
     'images',
     'wagtailmarkdown',
     'nhs_wagtailadmin',
+    'corsheaders',
 
     'wagtail.wagtailforms',
     'wagtail.wagtailredirects',
@@ -70,6 +71,8 @@ MIDDLEWARE = [
 
     'wagtail.wagtailcore.middleware.SiteMiddleware',
     'wagtail.wagtailredirects.middleware.RedirectMiddleware',
+
+    'corsheaders.middleware.CorsMiddleware',
 ]
 
 ROOT_URLCONF = 'nhsuk.urls'

--- a/nhsuk/settings/dev.py
+++ b/nhsuk/settings/dev.py
@@ -14,6 +14,8 @@ PREVIEW_SIGNATURE_KEY = 'mxwtt97p8[)89+Qm8xwMWTXK](Qc&MhdT=dW72bfhL/du4({sR'
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
+WAGTAILAPI_BASE_URL = "http://localhost:8000"
+
 
 # importing test settings file if necessary
 if sys.argv[1:2] == ['test']:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,3 +5,4 @@ psycopg2==2.6.2
 requests==2.12.1
 pyquery==1.2.17
 django-oauth-toolkit==0.10.0
+django-cors-headers==1.3.1


### PR DESCRIPTION
1. Set API base URL to include port
2. Add django-cors-headers to requirements to allow configure Wagtail to respond to remote queries to its API.

Add the following settings to your `settings/local.py`:

1. Add your client's host to `CORS_ORIGIN_WHITELIST`:
```py
CORS_ORIGIN_WHITELIST = (
    'localhost:8080',
)
```

2. Enable `CORS_ALLOW_CREDENTIALS` to use domain cookies (allowing to authenticate in browser):
```py
CORS_ALLOW_CREDENTIALS = True
```