### PR TITLE
Move api fields to the router (from the model)

### DIFF
--- a/api/router.py
+++ b/api/router.py
@@ -25,6 +25,14 @@ class BasePagesAPIEndpoint(WagtailPagesAPIEndpoint):
     base_serializer_class = PageSerializer
     renderer_classes = [CamelCaseJSONRenderer]
 
+    body_fields = WagtailPagesAPIEndpoint.body_fields + [
+        'guide'
+    ]
+
+    meta_fields = WagtailPagesAPIEndpoint.meta_fields + [
+        'children', 'siblings'
+    ]
+
 
 class PagesAPIEndpoint(BasePagesAPIEndpoint):
     """

--- a/pages/models.py
+++ b/pages/models.py
@@ -130,10 +130,7 @@ class EditorialPage(ChildrenSiblingsMixin, Page):
     # API
     api_fields = [
         'sidebar_order', 'non_emergency_callout', 'choices_origin',
-        'local_header', 'before', 'main', 'sidebar', 'guide'
-    ]
-    api_meta_fields = [
-        'children', 'siblings'
+        'local_header', 'before', 'main', 'sidebar'
     ]
 
 
@@ -155,12 +152,4 @@ class FolderPage(ChildrenSiblingsMixin, Page):
         MultiFieldPanel([
             FieldPanel('slug'),
         ], ugettext_lazy('Common page configuration')),
-    ]
-
-    # API
-    api_fields = [
-        'guide'
-    ]
-    api_meta_fields = [
-        'children', 'siblings'
     ]


### PR DESCRIPTION
As the Admin API share the same Frontent API logic, this moves the fields used only by the frontend to the router instead.