### PR TITLE
Upgrade to Wagtail 1.8

### DIFF
--- a/api/tests/pages/base.py
+++ b/api/tests/pages/base.py
@@ -1,10 +1,10 @@
 from datetime import timedelta
 
+from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.utils.timezone import now
-from oauth2_provider.compat import get_user_model
 from oauth2_provider.models import AccessToken, get_application_model
 from wagtail.wagtailcore.models import Page, Site
 

--- a/images/tests/test_blocks.py
+++ b/images/tests/test_blocks.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from django.test import TestCase
 from wagtail.wagtailcore.models import Collection
-from wagtail.wagtailimages.models import get_image_model
+from wagtail.wagtailimages import get_image_model
 from wagtail.wagtailimages.tests.utils import get_test_image_file
 
 from images.blocks import ImageChooserBlock

--- a/images/tests/test_models.py
+++ b/images/tests/test_models.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 from wagtail.wagtailcore.models import Collection
-from wagtail.wagtailimages.models import get_image_model
+from wagtail.wagtailimages import get_image_model
 from wagtail.wagtailimages.tests.utils import get_test_image_file
 
 

--- a/images/views.py
+++ b/images/views.py
@@ -9,8 +9,9 @@ from django.http import (
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import classonlymethod
 from django.views.generic import View
+from wagtail.wagtailimages import get_image_model
 from wagtail.wagtailimages.exceptions import InvalidFilterSpecError
-from wagtail.wagtailimages.models import SourceImageIOError, get_image_model
+from wagtail.wagtailimages.models import SourceImageIOError
 from wagtail.wagtailimages.views.serve import verify_signature
 
 

--- a/nhs_wagtailadmin/templates/wagtailadmin/home/pages_for_moderation.html
+++ b/nhs_wagtailadmin/templates/wagtailadmin/home/pages_for_moderation.html
@@ -20,7 +20,7 @@
                         <tr>
                             <td class="title" valign="top" colspan="2">
                                 <h2>
-                                    {{ revision.page.title }}
+                                    {{ revision.page.get_admin_display_title }}
 
                                     {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=revision.page %}
                                     {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=revision.page %}

--- a/nhs_wagtailadmin/templates/wagtailadmin/home/recent_edits.html
+++ b/nhs_wagtailadmin/templates/wagtailadmin/home/recent_edits.html
@@ -15,28 +15,28 @@
                     </tr>
                 </thead>
                 <tbody>
-                    {% for revision in last_edits %}
+                    {% for revision, page in last_edits %}
                         <tr>
                             <td class="title" valign="top">
                                 <h2>
-                                    {{ revision.page.title }}
+                                    {{ page.get_admin_display_title }}
 
-                                    {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=revision.page %}
-                                    {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=revision.page %}
+                                    {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}
+                                    {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}
                                 </h2>
                                 <ul class="actions">
-                                    <li><a href="{% url 'wagtailadmin_pages:edit' revision.page.id %}" class="button button-small button-secondary">{% trans "Edit" %}</a></li>
-                                    {% if revision.page.has_unpublished_changes %}
-                                        <li><a href="{% url 'wagtailadmin_pages:view_draft' revision.page.id %}" class="button button-small button-secondary" target="_blank">{% trans 'Draft' %}</a></li>
+                                    <li><a href="{% url 'wagtailadmin_pages:edit' page.id %}" class="button button-small button-secondary">{% trans "Edit" %}</a></li>
+                                    {% if page.has_unpublished_changes %}
+                                        <li><a href="{% url 'wagtailadmin_pages:view_draft' page.id %}" class="button button-small button-secondary" target="_blank">{% trans 'Draft' %}</a></li>
                                     {% endif %}
-                                    {% if revision.page.live %}
-                                        <li><a href="{{ revision.page.url }}" class="button button-small button-secondary" target="_blank">{% trans 'Live' %}</a></li>
+                                    {% if page.live %}
+                                        <li><a href="{{ page.url }}" class="button button-small button-secondary" target="_blank">{% trans 'Live' %}</a></li>
                                     {% endif %}
                                 </ul>
                             </td>
                             <td valign="top"><div class="human-readable-date" title="{{ revision.created_at|date:"d M Y H:i" }}">{{ revision.created_at|timesince }} ago</div></td>
                             <td valign="top">
-                                {% include "wagtailadmin/shared/page_status_tag.html" with page=revision.page %}
+                                {% include "wagtailadmin/shared/page_status_tag.html" with page=page %}
                             </td>
                         </tr>
                     {% endfor %}

--- a/nhs_wagtailadmin/templates/wagtailadmin/pages/listing/_list.html
+++ b/nhs_wagtailadmin/templates/wagtailadmin/pages/listing/_list.html
@@ -1,90 +1,77 @@
 {% load i18n %}
 {% load wagtailadmin_tags %}
 <table class="listing {% if full_width %}full-width{% endif %} {% block table_classname %}{% endblock %}">
-  {% if show_ordering_column %}
-    <col width="50px"/>
-  {% endif %}
-  <col/>
-  {% if show_parent %}
-    <col/>
-  {% endif %}
-  <col width="12%"/>
-  <col width="12%"/>
-  <col width="12%"/>
-  <col width="10%"/>
-  <thead>
-  {% block pre_parent_page_headers %}
-  {% endblock %}
-
-  {% if parent_page %}
-    {% page_permissions parent_page as parent_page_perms %}
-    <tr class="index {% if not parent_page.live %} unpublished{% endif %}
-      {% block parent_page_row_classname %}{% endblock %}">
-      <td class="title" {% if show_ordering_column %}colspan="2"{% endif %}>
-        {% block parent_page_title %}
+    {% if show_ordering_column %}
+        <col width="50px" />
+    {% endif %}
+    <col />
+    {% if show_parent %}
+        <col />
+    {% endif %}
+    <col width="12%" />
+    <col width="12%" />
+    <col width="12%" />
+    <col width="10%" />
+    <thead>
+        {% block pre_parent_page_headers %}
         {% endblock %}
-      </td>
-      <td class="updated" valign="bottom">
-        {% if parent_page.latest_revision_created_at %}
-          <div class="human-readable-date" title="{{ parent_page.latest_revision_created_at|date:"d M Y H:i" }}">
-            {{ parent_page.latest_revision_created_at|timesince }} ago
-          </div>
-        {% endif %}
-      </td>
-      <td class="type" valign="bottom">
-        {% if not parent_page.is_root %}
-          {{ parent_page.content_type.model_class.get_verbose_name }}
-        {% endif %}
-      </td>
-      <td class="status" valign="bottom">
-        {% if not parent_page.is_root %}
-          {% include "wagtailadmin/shared/page_status_tag.html" with page=parent_page %}
-        {% endif %}
-      </td>
-    </tr>
-  {% endif %}
 
-  {% block post_parent_page_headers %}
-  {% endblock %}
-  </thead>
-  <tbody>
-  {% if pages %}
-    {% for page in pages %}
-      {% page_permissions page as page_perms %}
-      <tr {% if ordering == "ord" %}id="page_{{ page.id }}" data-page-title="{{ page.title }}"{% endif %}
-          class="{% if not page.live %}unpublished{% endif %} {% block page_row_classname %}{% endblock %}">
-        {% if show_ordering_column %}
-          <td class="ord">{% if orderable and ordering == "ord" %}
-            <div class="handle icon icon-grip text-replace">{% trans 'Drag' %}</div>{% endif %}</td>
+        {% if parent_page %}
+            {% page_permissions parent_page as parent_page_perms %}
+            <tr class="index {% if not parent_page.live %} unpublished{% endif %} {% block parent_page_row_classname %}{% endblock %}">
+                <td class="title" {% if show_ordering_column %}colspan="2"{% endif %}>
+                    {% block parent_page_title %}
+                    {% endblock %}
+                </td>
+                <td class="updated" valign="bottom">{% if parent_page.latest_revision_created_at %}<div class="human-readable-date" title="{{ parent_page.latest_revision_created_at|date:"d M Y H:i" }}">{{ parent_page.latest_revision_created_at|timesince }} ago</div>{% endif %}</td>
+                <td class="type" valign="bottom">
+                    {% if not parent_page.is_root %}
+                        {{ parent_page.content_type.model_class.get_verbose_name }}
+                    {% endif %}
+                </td>
+                <td class="status" valign="bottom">
+                    {% if not parent_page.is_root %}
+                        {% include "wagtailadmin/shared/page_status_tag.html" with page=parent_page %}
+                    {% endif %}
+                </td>
+            </tr>
         {% endif %}
-        <td class="title" valign="top" data-listing-page-title>
-          {% block page_title %}
-          {% endblock %}
-        </td>
-        {% if show_parent %}
-          {% with page.get_parent as parent %}
-            <td class="parent" valign="top">
-              {% if parent %}
-                <a href="{% url 'wagtailadmin_explore' parent.id %}">{{ parent.title }}</a>
-              {% endif %}
-            </td>
-          {% endwith %}
-        {% endif %}
-        <td class="updated" valign="top">{% if page.latest_revision_created_at %}
-          <div class="human-readable-date"
-               title="{{ page.latest_revision_created_at|date:"d M Y H:i" }}">{{ page.latest_revision_created_at|timesince }}
-            ago
-          </div>{% endif %}</td>
-        <td class="type" valign="top">{{ page.content_type.model_class.get_verbose_name }}</td>
-        <td class="status" valign="top">
-          {% include "wagtailadmin/shared/page_status_tag.html" with page=page %}
-        </td>
-        {% block page_navigation %}
+
+        {% block post_parent_page_headers %}
         {% endblock %}
-      </tr>
-    {% endfor %}
-  {% else %}
-    {% block no_results %}{% endblock %}
-  {% endif %}
-  </tbody>
+    </thead>
+    <tbody>
+        {% if pages %}
+            {% for page in pages %}
+                {% page_permissions page as page_perms %}
+                <tr {% if ordering == "ord" %}id="page_{{ page.id }}" data-page-title="{{ page.get_admin_display_title }}"{% endif %} class="{% if not page.live %}unpublished{% endif %} {% block page_row_classname %}{% endblock %}">
+                    {% if show_ordering_column %}
+                        <td class="ord">{% if orderable and ordering == "ord" %}<div class="handle icon icon-grip text-replace">{% trans 'Drag' %}</div>{% endif %}</td>
+                    {% endif %}
+                    <td class="title" valign="top" data-listing-page-title>
+                        {% block page_title %}
+                        {% endblock %}
+                    </td>
+                    {% if show_parent %}
+                        {% with page.get_parent as parent %}
+                            <td class="parent" valign="top">
+                                {% if parent %}
+                                    <a href="{% url 'wagtailadmin_explore' parent.id %}">{{ parent.get_admin_display_title }}</a>
+                                {% endif %}
+                            </td>
+                        {% endwith %}
+                    {% endif %}
+                    <td class="updated" valign="top">{% if page.latest_revision_created_at %}<div class="human-readable-date" title="{{ page.latest_revision_created_at|date:"d M Y H:i" }}">{{ page.latest_revision_created_at|timesince }} ago</div>{% endif %}</td>
+                    <td class="type" valign="top">{{ page.content_type.model_class.get_verbose_name }}</td>
+                    <td class="status" valign="top">
+                        {% include "wagtailadmin/shared/page_status_tag.html" with page=page %}
+                    </td>
+                    {% block page_navigation %}
+                    {% endblock %}
+                </tr>
+            {% endfor %}
+        {% else %}
+            {% block no_results %}{% endblock %}
+        {% endif %}
+    </tbody>
 </table>

--- a/nhs_wagtailadmin/templates/wagtailadmin/pages/listing/_list_explore.html
+++ b/nhs_wagtailadmin/templates/wagtailadmin/pages/listing/_list_explore.html
@@ -5,82 +5,65 @@
 {# Page listing include, customised for 'explore' mode #}
 
 {% block parent_page_title %}
-  {% include "wagtailadmin/pages/listing/_parent_page_title_explore.html" %}
+    {% include "wagtailadmin/pages/listing/_parent_page_title_explore.html" %}
 {% endblock %}
 
 {% block post_parent_page_headers %}
 
-  {% if parent_page %}
-    {% if parent_page.is_root %}
-      <tr>
-        <td colspan="5">
-          <div class="help-block help-info">
-            {% if perms.wagtailcore.add_site %}
-              {% url 'wagtailsites:index' as wagtailsites_index_url %}
-              <p>
-                {% blocktrans %}
-                  The root level is where you can add new sites to your Wagtail installation.
-                  Pages created here will not be accessible at any URL until they are associated with a site.
-                {% endblocktrans %}
-                {% if wagtailsites_index_url %}
-                  <a href="{{ wagtailsites_index_url }}">{% trans "Configure a site now." %}</a>
+    {% if parent_page %}
+        {% if parent_page.is_root %}
+            <tr><td colspan="5"><div class="help-block help-info">
+                {% if perms.wagtailcore.add_site %}
+                    {% url 'wagtailsites:index' as wagtailsites_index_url %}
+                    <p>
+                        {% blocktrans %}
+                            The root level is where you can add new sites to your Wagtail installation. Pages created here will not be accessible at any URL until they are associated with a site.
+                        {% endblocktrans %}
+                        {% if wagtailsites_index_url %}
+                            <a href="{{ wagtailsites_index_url }}">{% trans "Configure a site now." %}</a>
+                        {% endif %}
+                    </p>
+                    <p>
+                        {% blocktrans %}
+                            If you just want to add pages to an existing site, create them as children of the homepage instead.
+                        {% endblocktrans %}
+                    </p>
+                {% else %}
+                    {% blocktrans %}
+                        Pages created here will not be accessible at any URL. To add pages to an existing site, create them as children of the homepage.
+                    {% endblocktrans %}
                 {% endif %}
-              </p>
-              <p>
-                {% blocktrans %}
-                  If you just want to add pages to an existing site, create them as children of the homepage instead.
-                {% endblocktrans %}
-              </p>
-            {% else %}
-              {% blocktrans %}
-                Pages created here will not be accessible at any URL. To add pages to an existing site, create them as
-                children of the homepage.
-              {% endblocktrans %}
-            {% endif %}
-          </div>
-        </td>
-      </tr>
-    {% elif not parent_page.url %}
-      <tr>
-        <td colspan="5">
-          <div class="help-block help-warning">
-            {% if perms.wagtailcore.add_site %}
-              {% url 'wagtailsites:index' as wagtailsites_index_url %}
-              {% blocktrans %}
-                There is no site set up for this location. Pages created here will not be accessible at any URL until a
-                site is associated with this location.
-              {% endblocktrans %}
-              {% if wagtailsites_index_url %}
-                <a href="{{ wagtailsites_index_url }}">{% trans "Configure a site now." %}</a>
-              {% endif %}
-            {% else %}
-              {% blocktrans %}
-                There is no site record for this location. Pages created here will not be accessible at any URL.
-              {% endblocktrans %}
-            {% endif %}
-          </div>
-        </td>
-      </tr>
+            </div></td></tr>
+        {% elif not parent_page.url %}
+            <tr><td colspan="5"><div class="help-block help-warning">
+                {% if perms.wagtailcore.add_site %}
+                    {% url 'wagtailsites:index' as wagtailsites_index_url %}
+                    {% blocktrans %}
+                        There is no site set up for this location. Pages created here will not be accessible at any URL until a site is associated with this location.
+                    {% endblocktrans %}
+                    {% if wagtailsites_index_url %}
+                        <a href="{{ wagtailsites_index_url }}">{% trans "Configure a site now." %}</a>
+                    {% endif %}
+                {% else %}
+                    {% blocktrans %}
+                        There is no site record for this location. Pages created here will not be accessible at any URL.
+                    {% endblocktrans %}
+                {% endif %}
+            </div></td></tr>
+        {% endif %}
     {% endif %}
-  {% endif %}
 
-  {% include "wagtailadmin/pages/listing/_table_headers_explore.html" %}
+    {% include "wagtailadmin/pages/listing/_table_headers_explore.html" %}
 {% endblock %}
 
 {% block page_title %}
-  {% include "wagtailadmin/pages/listing/_page_title_explore.html" %}
+    {% include "wagtailadmin/pages/listing/_page_title_explore.html" %}
 {% endblock %}
 
 {% block page_navigation %}
 {% endblock %}
 
 {% block no_results %}
-  {% url 'wagtailadmin_pages:add_subpage' parent_page.id as add_page_url %}
-  <tr>
-    <td colspan="3" class="no-results-message"><p>{% trans "No pages have been created at this location." %}
-      {% if parent_page and parent_page_perms.can_add_subpage %}
-        {% blocktrans %}Why not <a href="{{ add_page_url }}">create one</a>?{% endblocktrans %}
-      {% endif %}
-    </td>
-  </tr>
+    {% url 'wagtailadmin_pages:add_subpage' parent_page.id as add_page_url%}
+    <tr><td colspan="3" class="no-results-message"><p>{% trans "No pages have been created at this location." %}{% if parent_page and parent_page_perms.can_add_subpage %} {% blocktrans %}Why not <a href="{{ add_page_url }}">create one</a>?{% endblocktrans %}{% endif %}</td></tr>
 {% endblock %}

--- a/nhs_wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_explore.html
+++ b/nhs_wagtailadmin/templates/wagtailadmin/pages/listing/_page_title_explore.html
@@ -3,18 +3,16 @@
 {# The title field for a page in the page listing, when in 'explore' mode #}
 
 <h2>
-  {% if page.is_navigable %}
-    <a href="{% url 'wagtailadmin_explore' page.id %}" class="folder">
-      {{ page.title }}
-    </a>
-  {% else %}
-    {{ page.title }}
-  {% endif %}
+    {% if page.is_navigable %}
+        <a href="{% url 'wagtailadmin_explore' page.id %}" class="folder">{{ page.get_admin_display_title }}</a>
+    {% else %}
+        {{ page.get_admin_display_title }}
+    {% endif %}
 
-  {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}
-  {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}
+    {% include "wagtailadmin/pages/listing/_privacy_indicator.html" with page=page %}
+    {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=page %}
 </h2>
 
 <ul class="actions">
-  {% page_listing_buttons page page_perms %}
+    {% page_listing_buttons page page_perms %}
 </ul>

--- a/nhs_wagtailadmin/templates/wagtailadmin/pages/listing/_parent_page_title_explore.html
+++ b/nhs_wagtailadmin/templates/wagtailadmin/pages/listing/_parent_page_title_explore.html
@@ -4,12 +4,12 @@
 {# The title field for a parent page when the listing is in 'explore' mode #}
 
 <h2{% if parent_page.is_navigable %} class="folder"{% endif %}>
-  {{ parent_page.title }}
-  {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=parent_page %}
+    {{ parent_page.get_admin_display_title }}
+    {% include "wagtailadmin/pages/listing/_locked_indicator.html" with page=parent_page %}
 </h2>
 
 {% include "wagtailadmin/pages/_privacy_switch.html" with page=parent_page %}
 
 <ul class="actions">
-  {% page_listing_buttons parent_page parent_page_perms is_parent=True %}
+    {% page_listing_buttons parent_page parent_page_perms is_parent=True %}
 </ul>

--- a/nhs_wagtailadmin/templates/wagtailadmin/pages/listing/_table_headers_explore.html
+++ b/nhs_wagtailadmin/templates/wagtailadmin/pages/listing/_table_headers_explore.html
@@ -16,60 +16,54 @@ ordering: the current sort parameter
 {% endcomment %}
 
 <tr class="table-headers">
-  {% if show_ordering_column %}
-    <th class="ord">
-      {% if orderable %}
-        {% if ordering == "ord" %}
-          <a href="{% url 'wagtailadmin_explore' parent_page.id %}" class="icon icon-order text-replace"
-             title="{% trans 'Disable ordering of child pages' %}">{% trans 'Order' %}</a>
+    {% if show_ordering_column %}
+        <th class="ord">
+            {% if orderable %}
+                {% if ordering == "ord" %}
+                    <a href="{% url 'wagtailadmin_explore' parent_page.id %}" class="icon icon-order text-replace" title="{% trans 'Disable ordering of child pages' %}">{% trans 'Order' %}</a>
+                {% else %}
+                    <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering=ord" class="icon icon-order text-replace" title="{% trans 'Enable ordering of child pages' %}">{% trans 'Order' %}</a>
+                {% endif %}
+            {% endif %}
+        </th>
+    {% endif %}
+    <th class="title">
+        {% if sortable %}
+            <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == 'title' %}-{% endif %}title" class="icon icon-arrow-{% if ordering == 'title' %}down-after{% elif ordering == '-title' %}up-after{% else %}down-after{% endif %} {% if ordering == 'title' or ordering == '-title' %}teal{% endif %}">
+                {% trans 'Title' %}
+            </a>
         {% else %}
-          <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering=ord" class="icon icon-order text-replace"
-             title="{% trans 'Enable ordering of child pages' %}">{% trans 'Order' %}</a>
+            {% trans 'Title' %}
         {% endif %}
-      {% endif %}
     </th>
-  {% endif %}
-  <th class="title">
-    {% if sortable %}
-      <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == 'title' %}-{% endif %}title"
-         class="icon icon-arrow-{% if ordering == 'title' %}down-after{% elif ordering == '-title' %}up-after{% else %}down-after{% endif %} {% if ordering == 'title' or ordering == '-title' %}teal{% endif %}">
-        {% trans 'Title' %}
-      </a>
-    {% else %}
-      {% trans 'Title' %}
-    {% endif %}
-  </th>
-  {% if show_parent %}
+    {% if show_parent %}
     <th class="parent">{% trans 'Parent' %}</th>
-  {% endif %}
-  <th class="updated">
-    {% if sortable %}
-      <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == 'latest_revision_created_at' %}-{% endif %}latest_revision_created_at"
-         class="icon icon-arrow-{% if ordering == '-latest_revision_created_at' %}up-after{% else %}down-after{% endif %} {% if ordering == 'latest_revision_created_at' or ordering == '-latest_revision_created_at' %}teal {% endif %}">
-        {% trans 'Updated' %}
-      </a>
-    {% else %}
-      {% trans 'Updated' %}
     {% endif %}
-  </th>
-  <th class="type">
-    {% if sortable %}
-      <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == 'content_type' %}-{% endif %}content_type"
-         class="icon icon-arrow-{% if ordering == '-content_type' %}up-after{% else %}down-after{% endif %} {% if ordering == 'content_type' or ordering == '-content_type' %}teal {% endif %}">
-        {% trans 'Type' %}
-      </a>
-    {% else %}
-      {% trans 'Type' %}
-    {% endif %}
-  </th>
-  <th class="status">
-    {% if sortable %}
-      <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == 'live' %}-{% endif %}live"
-         class="icon icon-arrow-{% if ordering == '-live' %}up-after{% else %}down-after{% endif %} {% if ordering == 'live' or ordering == '-live' %}teal {% endif %}">
-        {% trans 'Status' %}
-      </a>
-    {% else %}
-      {% trans 'Status' %}
-    {% endif %}
-  </th>
+     <th class="updated">
+        {% if sortable %}
+            <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == 'latest_revision_created_at' %}-{% endif %}latest_revision_created_at" class="icon icon-arrow-{% if ordering == '-latest_revision_created_at' %}up-after{% else %}down-after{% endif %} {% if ordering == 'latest_revision_created_at' or ordering == '-latest_revision_created_at' %}teal {% endif %}">
+                {% trans 'Updated' %}
+            </a>
+        {% else %}
+            {% trans 'Updated' %}
+        {% endif %}
+    </th>
+    <th class="type">
+        {% if sortable %}
+            <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == 'content_type' %}-{% endif %}content_type" class="icon icon-arrow-{% if ordering == '-content_type' %}up-after{% else %}down-after{% endif %} {% if ordering == 'content_type' or ordering == '-content_type' %}teal {% endif %}">
+                {% trans 'Type' %}
+            </a>
+        {% else %}
+            {% trans 'Type' %}
+        {% endif %}
+    </th>
+    <th class="status">
+        {% if sortable %}
+            <a href="{% url 'wagtailadmin_explore' parent_page.id %}?ordering={% if ordering == 'live' %}-{% endif %}live" class="icon icon-arrow-{% if ordering == '-live' %}up-after{% else %}down-after{% endif %} {% if ordering == 'live' or ordering == '-live' %}teal {% endif %}">
+                {% trans 'Status' %}
+            </a>
+        {% else %}
+            {% trans 'Status' %}
+        {% endif %}
+    </th>
 </tr>

--- a/pages/blocks.py
+++ b/pages/blocks.py
@@ -1,5 +1,6 @@
-from wagtail.wagtailcore.blocks import Block
 from wagtail.wagtailcore.blocks.list_block import ListBlock as WagtailListBlock
+from wagtail.wagtailcore.blocks.static_block import \
+    StaticBlock as WagtailStaticBlock
 from wagtail.wagtailcore.blocks.stream_block import \
     StreamBlock as WagtailStreamBlock
 from wagtail.wagtailcore.blocks.struct_block import \
@@ -62,21 +63,6 @@ class StructBlock(WagtailStructBlock):
         ])
 
 
-class StaticBlock(Block):
-    """
-    Very simple static block that only returns the value given as init param.
-    When added to a page, the frontend can use it to trigger some related logic that doesn't
-    require any particular dynamic block content.
-    """
-    def __init__(self, value, *args, **kwargs):
-        self.value = value
-        super(StaticBlock, self).__init__(*args, **kwargs)
-
-    def render_form(self, *args, **kwargs):
-        return self.value
-
-    def value_from_datadict(self, *args, **kwargs):
-        return self.value
-
-    class Meta:
-        default = None
+class StaticBlock(WagtailStaticBlock):
+    def value_from_datadict(self, data, files, prefix):
+        return self.name

--- a/pages/migrations/0005_auto_20161118_1530.py
+++ b/pages/migrations/0005_auto_20161118_1530.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='editorialpage',
             name='local_header',
-            field=wagtail.wagtailcore.fields.StreamField((('markdown', wagtail.wagtailcore.blocks.RichTextBlock(label='markdown')), ('sectionNav', pages.blocks.StaticBlock('Section Navigation', label='section nav'))), blank=True, null=True),
+            field=wagtail.wagtailcore.fields.StreamField((('markdown', wagtail.wagtailcore.blocks.RichTextBlock(label='markdown')), ('sectionNav', pages.blocks.StaticBlock(admin_text='Section Navigation', label='section nav'))), blank=True, null=True),
         ),
         migrations.AlterField(
             model_name='editorialpage',

--- a/pages/page_elements.py
+++ b/pages/page_elements.py
@@ -31,7 +31,7 @@ class Components(object):
         'image': ImageChooserBlock,
         'figureList': partial(ListBlock, ImageChooserBlock()),
         'sectionList': section_list,
-        'sectionNav': partial(StaticBlock, 'Section Navigation')
+        'sectionNav': partial(StaticBlock, admin_text='Section Navigation')
     }
 
     @classmethod

--- a/pages/tests/test_blocks.py
+++ b/pages/tests/test_blocks.py
@@ -1,11 +1,10 @@
-from unittest import mock
 
 from django.test import TestCase
 from wagtail.wagtailcore.blocks.field_block import CharBlock
 from wagtail.wagtailcore.blocks.stream_block import StreamValue
 from wagtail.wagtailcore.blocks.struct_block import StructValue
 
-from pages.blocks import ListBlock, StaticBlock, StreamBlock, StructBlock
+from pages.blocks import ListBlock, StreamBlock, StructBlock
 
 
 class TestCharBlock(CharBlock):
@@ -112,27 +111,3 @@ class StructBlockTestCase(TestCase):
             context={}
         )
         self.assertEqual(representation, {'test': expected})
-
-
-class StaticBlockTestCase(TestCase):
-    def setUp(self):
-        super(StaticBlockTestCase, self).setUp()
-
-        self.value = 'some value'
-        self.block = StaticBlock(self.value)
-
-    def test_render_form_returns_static_value(self):
-        self.assertEqual(
-            self.block.render_form(
-                mock.MagicMock(), prefix=mock.MagicMock(), errors=mock.MagicMock()
-            ),
-            self.value
-        )
-
-    def test_value_from_datadict_returns_static_value(self):
-        self.assertEqual(
-            self.block.value_from_datadict(
-                mock.MagicMock(), mock.MagicMock(), mock.MagicMock()
-            ),
-            self.value
-        )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,8 +1,8 @@
-Django>=1.10.3,<1.11
-wagtail>=1.7,<1.8
+Django>=1.10.4,<1.11
+wagtail>=1.8,<1.9
 djangorestframework-camel-case==0.2.0
 psycopg2==2.6.2
-requests==2.12.1
+requests==2.12.4
 pyquery==1.2.17
-django-oauth-toolkit==0.10.0
+django-oauth-toolkit==0.11.0
 django-cors-headers==1.3.1


### PR DESCRIPTION
This updates the templates that we overrode. Next time, let's make sure we only change the bits that we need to change instead of reformatting the file as that makes it harder to spot changes.

The new Wagtail has a new `StaticBlock` very similar to the one I created so I switched to using that.

Made a few minor updates recommended by the Wagtail team.