### PR TITLE
Remove md spell checker, preview and placeholder

### DIFF
--- a/nhsuk/settings/base.py
+++ b/nhsuk/settings/base.py
@@ -166,7 +166,17 @@ WAGTAILIMAGES_IMAGE_MODEL = 'images.Image'
 
 WAGTAILADMIN_RICH_TEXT_EDITORS = {
     'default': {
-        'WIDGET': 'wagtailmarkdown.rich_text.SimpleMDETextArea'
+        'WIDGET': 'wagtailmarkdown.rich_text.SimpleMDETextArea',
+        'OPTIONS': {
+            'spellChecker': False,
+            'placeholder': ' ',
+            'toolbar': [
+                "bold", "italic", "heading", "|",
+                "quote", "unordered-list", "ordered-list", "|",
+                "link", "|",
+                "guide"
+            ],
+        }
     },
 }
 

--- a/wagtailmarkdown/rich_text.py
+++ b/wagtailmarkdown/rich_text.py
@@ -52,12 +52,11 @@ class SimpleMDETextArea(WidgetWithScript, widgets.Textarea):
 
     def __init__(self, attrs=None, **kwargs):
         super(SimpleMDETextArea, self).__init__(attrs)
-        self.kwargs = dict(self.getDefaultArgs())
-        if kwargs is not None:
-            self.kwargs.update(kwargs)
+        self.options = dict(self.getDefaultArgs())
+        self.options.update(kwargs.get('options', {}))
 
     def get_panel(self):
         return RichTextFieldPanel
 
     def render_js_init(self, id_, name, value):
-        return "initSimpleMDE({0}, {1});".format(json.dumps(id_), json.dumps(self.kwargs))
+        return "initSimpleMDE({0}, {1});".format(json.dumps(id_), json.dumps(self.options))


### PR DESCRIPTION
This changes the `SimpleMDE` markdown editor and gets rid of:
- the spellChecker because it was annoying and not always useful
- the preview and the split functionality because it didn't carry
the live formatting/styling and it was confusing content designers
- the fullscreen functionality as not obviously useful
- placeholder

**Before**
![screen shot 2017-01-26 at 15 49 39](https://cloud.githubusercontent.com/assets/178865/22338408/33ea98b6-e3df-11e6-8857-b3cb73321b6c.png)

**After**
![screen shot 2017-01-26 at 15 51 04](https://cloud.githubusercontent.com/assets/178865/22338447/4827d528-e3df-11e6-91e6-efbb001ff765.png)
