### PR TITLE
Make grey markdown links darker

### DIFF
--- a/nhs_wagtailadmin/static/nhs_wagtailadmin/css/nhs-overrides.css
+++ b/nhs_wagtailadmin/static/nhs_wagtailadmin/css/nhs-overrides.css
@@ -88,3 +88,9 @@ li.sequence-member .sequence-type-fixed-list li.required > label:after {
   overflow: visible;
   padding: 0;
 }
+
+/* Makes links in the markdown editor darker */
+.CodeMirror.CodeMirror-wrap .CodeMirror-code .cm-link,
+.CodeMirror.CodeMirror-wrap .CodeMirror-code .cm-url {
+  color: #555;
+}


### PR DESCRIPTION
Greyed-out link text in mark up is hard to read, this makes it darker.


**Before**:
![grey links before](https://cloud.githubusercontent.com/assets/178865/22417910/7d1e8ba4-e6ce-11e6-84f3-d690bf8dbc7e.png)

**After**:
![grey links after](https://cloud.githubusercontent.com/assets/178865/22417917/872e5f5c-e6ce-11e6-93ac-0f9b0d334449.png)
