### PR TITLE
Make grey markdown links blue

### DIFF
--- a/nhs_wagtailadmin/static/nhs_wagtailadmin/css/nhs-overrides.css
+++ b/nhs_wagtailadmin/static/nhs_wagtailadmin/css/nhs-overrides.css
@@ -90,7 +90,9 @@ li.sequence-member .sequence-type-fixed-list li.required > label:after {
 }
 
 /* Makes links in the markdown editor darker */
-.CodeMirror.CodeMirror-wrap .CodeMirror-code .cm-link,
+.CodeMirror.CodeMirror-wrap .CodeMirror-code .cm-link {
+  color: inherit;
+}
 .CodeMirror.CodeMirror-wrap .CodeMirror-code .cm-url {
-  color: #555;
+  color: #0072c6;
 }


### PR DESCRIPTION
It seems like blue links work better than dark grey ones.

**Before:**
![grey links after](https://cloud.githubusercontent.com/assets/178865/22427030/6f7b7464-e6f9-11e6-9b59-35335b0c6701.png)

**After:**
![grey links after after](https://cloud.githubusercontent.com/assets/178865/22427036/7527bbc0-e6f9-11e6-8470-1aad35cf7c43.png)
