### PR TITLE
Create external files with md text when exporting

### DIFF
--- a/exporter/components.py
+++ b/exporter/components.py
@@ -1,0 +1,126 @@
+import copy
+import os
+import sys
+
+
+class Component(object):
+    def __init__(self, context):
+        self.context = context
+
+    def transform(self, data):
+        return data
+
+
+class StructuralComponent(Component):
+    COMPONENTS = {
+        'text': 'TextComponent',
+        'splitContent': 'SplitContentComponent',
+        'splitArea': 'SplitAreaComponent',
+        'gallery': 'GalleryComponent',
+        'image': 'ImageComponent',
+        'callout': 'CalloutComponent',
+        'panel': 'PanelComponent',
+        'reveal': 'RevealComponent',
+        'tabs': 'TabsComponent',
+        'tab': 'TabComponent',
+    }
+    CHILDREN_PROPS = ['children']
+
+    def load_component(self, component_type):
+        component = getattr(
+            sys.modules[__name__],
+            self.COMPONENTS[component_type]
+        )
+        return component(self.context)
+
+    def transform_components(self, data):
+        transformed_data = []
+        for comp_data in data:
+            component = self.load_component(comp_data['type'])
+            transformed_data.append(
+                component.transform(comp_data)
+            )
+        return transformed_data
+
+    def transform(self, data):
+        transformed_data = copy.deepcopy(data)
+        for child_prop in self.CHILDREN_PROPS:
+            transformed_data['props'][child_prop] = self.transform_components(
+                transformed_data['props'][child_prop]
+            )
+        return transformed_data
+
+
+class TextComponent(Component):
+    MD_FILENAME_FORMAT = 'content-{count}.md'
+
+    @property
+    def md_files(self):
+        if 'new_files' not in self.context:
+            self.context['new_files'] = []
+        return self.context['new_files']
+
+    @property
+    def item_base_path(self):
+        return self.context['item_base_path']
+
+    def get_build_path(self, filename):
+        return os.path.join(self.item_base_path, filename)
+
+    def transform(self, data):
+        """
+        Converts md content into '!file=content-n.md' value and populates the
+        'new_files' list with the extra file to create.
+        This is so that md content is saved into external and more manageable files.
+        """
+        if data['props']['variant'] != 'markdown':
+            return data
+
+        md_content = data['props']['value']
+        md_filename = self.MD_FILENAME_FORMAT.format(count=(len(self.md_files) + 1))
+
+        return_data = copy.deepcopy(data)
+        return_data['props']['value'] = '!file=%s' % md_filename
+
+        self.md_files.append(
+            (self.get_build_path(md_filename), md_content)
+        )
+
+        return return_data
+
+
+class ImageComponent(Component):
+    def transform(self, data):
+        return data
+
+
+class SplitContentComponent(StructuralComponent):
+    CHILDREN_PROPS = ['children']
+
+
+class SplitAreaComponent(StructuralComponent):
+    CHILDREN_PROPS = ['children']
+
+
+class GalleryComponent(StructuralComponent):
+    CHILDREN_PROPS = ['children']
+
+
+class CalloutComponent(StructuralComponent):
+    CHILDREN_PROPS = ['children']
+
+
+class PanelComponent(StructuralComponent):
+    CHILDREN_PROPS = ['header', 'body', 'footer']
+
+
+class RevealComponent(StructuralComponent):
+    CHILDREN_PROPS = ['children']
+
+
+class TabsComponent(StructuralComponent):
+    CHILDREN_PROPS = ['children']
+
+
+class TabComponent(StructuralComponent):
+    CHILDREN_PROPS = ['children']

--- a/exporter/tests/test_components.py
+++ b/exporter/tests/test_components.py
@@ -1,0 +1,137 @@
+import copy
+from unittest import TestCase
+
+from .. import components
+
+DEFAULT_MD_COMPONENT_DATA = {
+    'type': 'text',
+    'props': {
+        'variant': 'markdown',
+        'value': 'lorem ipsum'
+    }
+}
+
+
+class TextComponentTestCase(TestCase):
+    def test_doesnt_change_data_if_isnt_markdown(self):
+        """
+        If component['type']['variant'] isn't 'markdown',
+        the data shouldn't change
+        """
+        data = copy.deepcopy(DEFAULT_MD_COMPONENT_DATA)
+        data['props']['variant'] = 'plain'
+
+        component = components.TextComponent(context={})
+        transformed_data = component.transform(data)
+        self.assertDictEqual(data, transformed_data)
+
+    def test_without_new_files(self):
+        """
+        If component['type']['variant'] is 'markdown' and context['new_files'] doesn't exist,
+        the method should tranform data to value == '!file=content-1.md' and context['new_files'] should
+        include a tuple of ('path-to-file-content-1.md', 'content of file')
+        """
+        data = copy.deepcopy(DEFAULT_MD_COMPONENT_DATA)
+
+        context = {
+            'item_base_path': '/item/path'
+        }
+        component = components.TextComponent(context)
+        transformed_data = component.transform(data)
+
+        self.assertNotEqual(data, transformed_data)
+        self.assertEqual(transformed_data['props']['value'], '!file=content-1.md')
+        self.assertEqual(context['new_files'], [('/item/path/content-1.md', 'lorem ipsum')])
+
+    def test_with_existing_new_files(self):
+        """
+        If component['type']['variant'] is 'markdown' and context['new_files'] already includes one file,
+        the method should tranform data to value == '!file=content-2.md' and context['new_files'] should
+        include a tuple of ('path-to-file-content-2.md', 'content of file')
+        """
+        data = copy.deepcopy(DEFAULT_MD_COMPONENT_DATA)
+
+        context = {
+            'item_base_path': '/item/path',
+            'new_files': [('/path/file1', 'content')]
+        }
+        component = components.TextComponent(context)
+        transformed_data = component.transform(data)
+
+        self.assertNotEqual(data, transformed_data)
+        self.assertEqual(transformed_data['props']['value'], '!file=content-2.md')
+        self.assertEqual(
+            context['new_files'],
+            [('/path/file1', 'content'), ('/item/path/content-2.md', 'lorem ipsum')]
+        )
+
+
+class StructuralComponentTestCase(object):
+    COMPONENT_TYPE = ''
+    COMPONENT_CLASS = None
+    CHILDREN_PROPS = ['children']
+
+    def test_recursive_transformation(self):
+        """
+        Tests that if the text component is a child of this structural component, it gets
+        transformed recursively.
+        """
+        data = {
+            'type': self.COMPONENT_TYPE,
+            'props': {}
+        }
+        for child_prop in self.CHILDREN_PROPS:
+            data['props'][child_prop] = [copy.deepcopy(DEFAULT_MD_COMPONENT_DATA)]
+
+        context = {
+            'item_base_path': '/item/path'
+        }
+        component = self.COMPONENT_CLASS(context)
+        transformed_data = component.transform(data)
+
+        for index, child_prop in enumerate(self.CHILDREN_PROPS, start=1):
+            self.assertEqual(
+                transformed_data['props'][child_prop][0]['props']['value'],
+                '!file=content-%s.md' % index
+            )
+
+
+class SplitContentComponentTestCase(StructuralComponentTestCase, TestCase):
+    COMPONENT_TYPE = 'splitContent'
+    COMPONENT_CLASS = components.SplitContentComponent
+
+
+class SplitAreaComponentTestCase(StructuralComponentTestCase, TestCase):
+    COMPONENT_TYPE = 'splitArea'
+    COMPONENT_CLASS = components.SplitAreaComponent
+
+
+class GalleryComponentTestCase(StructuralComponentTestCase, TestCase):
+    COMPONENT_TYPE = 'gallery'
+    COMPONENT_CLASS = components.GalleryComponent
+
+
+class CalloutComponentTestCase(StructuralComponentTestCase, TestCase):
+    COMPONENT_TYPE = 'callout'
+    COMPONENT_CLASS = components.CalloutComponent
+
+
+class PanelComponentTestCase(StructuralComponentTestCase, TestCase):
+    COMPONENT_TYPE = 'panel'
+    COMPONENT_CLASS = components.PanelComponent
+    CHILDREN_PROPS = ['header', 'body', 'footer']
+
+
+class RevealComponentTestCase(StructuralComponentTestCase, TestCase):
+    COMPONENT_TYPE = 'reveal'
+    COMPONENT_CLASS = components.RevealComponent
+
+
+class TabsComponentTestCase(StructuralComponentTestCase, TestCase):
+    COMPONENT_TYPE = 'tabs'
+    COMPONENT_CLASS = components.TabsComponent
+
+
+class TabComponentTestCase(StructuralComponentTestCase, TestCase):
+    COMPONENT_TYPE = 'tab'
+    COMPONENT_CLASS = components.TabComponent


### PR DESCRIPTION
This creates md files containing the content of the text components when exporting to make it easier for us to change check and change them manually if needed.

Those files will be named `content-1.md`, `content-2.md` etc.