### PR TITLE
Include camelCase components when importing

### DIFF
--- a/importer/components.py
+++ b/importer/components.py
@@ -22,7 +22,9 @@ class StructuralComponent(Component):
     COMPONENTS = {
         'text': 'TextComponent',
         'split_content': 'SplitContentComponent',
+        'splitContent': 'SplitContentComponent',
         'split_area': 'SplitAreaComponent',
+        'splitArea': 'SplitAreaComponent',
         'gallery': 'GalleryComponent',
         'image': 'ImageComponent',
         'callout': 'CalloutComponent',


### PR DESCRIPTION
The frontend seems to accept components with type fields in snake_case and CamelCase.
This adds support for camel case.