### PR TITLE
Only return siblings if parent page is a guide

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -29,6 +29,16 @@ class PageListField(Field):
         ]
 
 
+class SiblingsField(PageListField):
+    def get_attribute(self, instance):
+        return instance.get_guide_siblings()
+
+
+class ChildrenField(PageListField):
+    def get_attribute(self, instance):
+        return instance.get_live_children()
+
+
 class PageParentField(WagtailPageParentField):
     """
     Like the Wagtail PageParentField but using a consistent page serializer.
@@ -84,8 +94,8 @@ class ContentField(Field):
 
 class PageSerializer(WagtailPageSerializer):
     parent = PageParentField(read_only=True)
-    children = PageListField(read_only=True)
-    siblings = PageListField(read_only=True)
+    children = ChildrenField(read_only=True)
+    siblings = SiblingsField(read_only=True)
     content = ContentField(
         fields=[
             ('header', StreamField),

--- a/api/tests/pages/test_hierarchy.py
+++ b/api/tests/pages/test_hierarchy.py
@@ -119,9 +119,10 @@ class SiblingsTestCase(HierarchyBaseTestCase):
     Tests related to the `siblings` meta field of the Content JSON API Response.
     """
 
-    def test_with_siblings(self):
+    def test_siblings_if_parent_is_a_guide(self):
         """
-        Tests that the API response of a page with siblings is:
+        Tests that the API response of a page with parent.guide == True
+        includes siblings:
         {
             ...
             meta: {
@@ -136,6 +137,9 @@ class SiblingsTestCase(HierarchyBaseTestCase):
             }
         }
         """
+        self.folder.guide = True
+        self.folder.save()
+
         for page in self.live_pages:
             response = self.get_content_api_response(page.id)
             json_data = response.json()
@@ -145,25 +149,21 @@ class SiblingsTestCase(HierarchyBaseTestCase):
                 [sibling.id for sibling in self.live_pages]
             )
 
-    def test_without_siblings(self):
+    def test_no_siblings_if_parent_isnt_a_guide(self):
         """
-        Tests that the API response of a page without siblings only include the page itself:
+        Tests that the API response of a page with parent.guide == False
+        has empty siblings:
         {
             ...
             meta: {
-                siblings: [{
-                    ...
-                }]
+                siblings: []
             }
         }
         """
         response = self.get_content_api_response(page_id=self.folder.id)
         json_data = response.json()
 
-        self.assertEqual(
-            [data['id'] for data in json_data['meta']['siblings']],
-            [self.folder.id]
-        )
+        self.assertEqual(json_data['meta']['siblings'], [])
 
 
 class GuideTestCase(HierarchyBaseTestCase):

--- a/pages/migrations/0004_folderpage.py
+++ b/pages/migrations/0004_folderpage.py
@@ -5,8 +5,6 @@ from __future__ import unicode_literals
 import django.db.models.deletion
 from django.db import migrations, models
 
-import pages.models
-
 
 class Migration(migrations.Migration):
 
@@ -25,6 +23,6 @@ class Migration(migrations.Migration):
             options={
                 'abstract': False,
             },
-            bases=(pages.models.ChildrenSiblingsMixin, 'wagtailcore.page'),
+            bases=('wagtailcore.page',),
         ),
     ]

--- a/pages/models.py
+++ b/pages/models.py
@@ -34,19 +34,19 @@ class Page(WagtailPage):
     def serve_preview(self, request, mode_name):
         preview_via_POST_deprecated()
 
+    def get_live_children(self):
+        return self.get_children().live()
+
+    def get_guide_siblings(self):
+        if getattr(self.get_parent().specific, 'guide', False):
+            return self.get_siblings().live()
+        return []
+
     class Meta:
         proxy = True
 
 
-class ChildrenSiblingsMixin(object):
-    def children(self):
-        return self.get_children().live()
-
-    def siblings(self):
-        return self.get_siblings().live()
-
-
-class EditorialPage(ChildrenSiblingsMixin, Page):
+class EditorialPage(Page):
     # META
     non_emergency_callout = models.BooleanField(
         default=True,
@@ -108,7 +108,7 @@ class EditorialPage(ChildrenSiblingsMixin, Page):
     ]
 
 
-class FolderPage(ChildrenSiblingsMixin, Page):
+class FolderPage(Page):
     guide = models.BooleanField(
         default=False,
         help_text='If ticked, all its sub-pages will be part of this guide'

--- a/pages/tests/test_children_siblings.py
+++ b/pages/tests/test_children_siblings.py
@@ -68,7 +68,7 @@ class ChildrenTestCase(BaseTestCase):
         Tests that <page>.children() returns the list of live sub pages.
         """
         self.assertEqual(
-            [child.id for child in self.folder.children()],
+            [child.id for child in self.folder.get_live_children()],
             [child.id for child in self.live_pages]
         )
 
@@ -77,28 +77,29 @@ class ChildrenTestCase(BaseTestCase):
         Tests that if there aren't any live sub pages, <page>.children() returns [].
         """
         for page in self.all_pages:
-            self.assertEqual(list(page.children()), [])
+            self.assertEqual(list(page.get_live_children()), [])
 
 
 class SiblingsTestCase(BaseTestCase):
-    def test_with_siblings(self):
+    def test_siblings_if_parent_is_a_guide(self):
         """
-        Tests that <page>.siblings() returns the list of live siblings.
+        Tests that <page>.get_guide_siblings() returns the list of live siblings if parent.guide == True.
         """
+        self.folder.guide = True
+        self.folder.save()
+
         for page in self.live_pages:
             self.assertEqual(
-                [sibling.id for sibling in page.siblings()],
+                [sibling.id for sibling in page.get_guide_siblings()],
                 [sibling.id for sibling in self.live_pages]
             )
 
-    def test_without_siblings(self):
+    def test_no_siblings_if_parent_isnt_a_guide(self):
         """
-        Tests that if there aren't any siblings, <page>.siblings() will only include the page itself.
+        Tests that <page>.get_guide_siblings() returns [] if parent.guide == False.
         """
-        self.assertEqual(
-            [page.id for page in self.folder.siblings()],
-            [self.folder.id]
-        )
+        for page in self.live_pages:
+            self.assertEqual(page.get_guide_siblings(), [])
 
 
 class GuideTestCase(BaseTestCase):


### PR DESCRIPTION
This changes the API response to only return siblings of a page if its parent is a guide.