### PR TITLE
Fix circular dependency with components

### DIFF
--- a/pages/components/reveal.py
+++ b/pages/components/reveal.py
@@ -1,8 +1,8 @@
+from django.utils.functional import SimpleLazyObject
 from wagtail.wagtailcore.blocks import CharBlock, ChoiceBlock, StructBlock
 
 from ..blocks import StreamBlock
 from .base import Component
-from .gallery import gallery
 from .text import text
 
 
@@ -17,10 +17,32 @@ class RevealBlock(StructBlock):
         )
     )
 
-    children = StreamBlock([
-        text.as_tuple(),
-        gallery.as_tuple()
-    ], label='Content')
+    def __init__(self, *args, **kwargs):
+        children_stream_block = [
+            text.as_tuple()
+        ]
+
+        # if compact == True, don't allow any other sub-component
+        if not kwargs.pop('compact', False):
+            # importing components here avoids circular dependency
+            from .callout import callout_compact
+            from .gallery import gallery
+
+            children_stream_block += [
+                callout_compact.as_tuple(),
+                gallery.as_tuple()
+            ]
+
+        # configure sub-components
+        local_blocks = kwargs.get('local_blocks', [])
+        local_blocks.append(
+            ('children', StreamBlock(children_stream_block, label='Content'))
+        )
+        kwargs['local_blocks'] = local_blocks
+
+        super().__init__(*args, **kwargs)
 
 
-reveal = Component('reveal', RevealBlock(icon="radio-full"))
+# use a LazyObject for fully defined reveal so that we initialise it only when needed
+reveal = SimpleLazyObject(lambda: Component('reveal', RevealBlock(icon="radio-full")))
+reveal_compact = Component('reveal', RevealBlock(icon="radio-full", compact=True))

--- a/pages/tests/components/test_callout.py
+++ b/pages/tests/components/test_callout.py
@@ -1,0 +1,29 @@
+from unittest import TestCase
+
+from ...components.callout import callout, callout_compact
+
+
+class CalloutTestCase(TestCase):
+    def test_children_components_of_callout(self):
+        """
+        Tests that `callout` has a children stream prop with multiple sub-components
+        """
+        _, block = callout.as_tuple()
+
+        children_prop = block.child_blocks['children']
+        self.assertCountEqual(
+            children_prop.child_blocks.keys(),
+            ['text', 'reveal']
+        )
+
+    def test_children_components_of_callout_compact(self):
+        """
+        Tests that `callout_compact` has a children stream prop with just `text` as sub-component.
+        """
+        _, block = callout_compact.as_tuple()
+
+        children_prop = block.child_blocks['children']
+        self.assertCountEqual(
+            children_prop.child_blocks.keys(),
+            ['text']
+        )

--- a/pages/tests/components/test_reveal.py
+++ b/pages/tests/components/test_reveal.py
@@ -1,0 +1,29 @@
+from unittest import TestCase
+
+from ...components.reveal import reveal, reveal_compact
+
+
+class RevealTestCase(TestCase):
+    def test_children_components_of_reveal(self):
+        """
+        Tests that `reveal` has a children stream prop with multiple sub-components
+        """
+        _, block = reveal.as_tuple()
+
+        children_prop = block.child_blocks['children']
+        self.assertCountEqual(
+            children_prop.child_blocks.keys(),
+            ['text', 'gallery', 'callout']
+        )
+
+    def test_children_components_of_reveal_compact(self):
+        """
+        Tests that `reveal_compact` has a children stream prop with just `text` as sub-component.
+        """
+        _, block = reveal_compact.as_tuple()
+
+        children_prop = block.child_blocks['children']
+        self.assertCountEqual(
+            children_prop.child_blocks.keys(),
+            ['text']
+        )


### PR DESCRIPTION
This fixes the circular dependency by having two versions of some components, one with all possible sub-components and one 'compact' with just the text component.

Also, the full version is lazy loaded so that it's initialised only when needed.